### PR TITLE
feat: Add Output Format Selection (PNG/WEBP) (#11)

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,6 +148,15 @@ tk.Radiobutton(root, text="Select Folder", variable=file_or_folder, value="folde
 files_label = tk.Label(root, text="No files selected", fg="#0F0", bg="#333")
 files_label.pack(pady=5)
 
+# Output Format Selection
+format_label = tk.Label(root, text="Output Format:", bg="#333", fg="#FFF")
+format_label.pack()
+
+format_var = tk.StringVar(value="JPEG")
+format_menu = ttk.Combobox(root, textvariable=format_var, state="readonly")
+format_menu["values"] = ["JPEG", "PNG", "WEBP"]
+format_menu.pack(pady=5)
+
 # Checkboxes for options
 compress_var = tk.BooleanVar(value=True)
 auto_orient_var = tk.BooleanVar(value=False)
@@ -161,15 +170,5 @@ compress_button.pack(pady=20)
 # Progress Bar Widget
 progress_bar = ttk.Progressbar(root, orient='horizontal', length=400, mode='determinate')
 progress_bar.pack(pady=10)
-
-# Output Format Selection
-format_label = tk.Label(root, text="Output Format:", bg="#333", fg="#FFF")
-format_label.pack()
-
-format_var = tk.StringVar(value='JPEG')
-format_menu = ttk.Combobox(root, textvariable=format_var, state='readonly')
-format_menu['values'] = ['JPEG', 'PNG', 'WEBP']
-format_menu.pack(pady=5)
-
 
 root.mainloop()

--- a/main.py
+++ b/main.py
@@ -97,7 +97,7 @@ def compress_images() -> None:
                 else:
                     ext = f'.{selected_format.lower()}'
 
-                output_path: str = os.path.join(new_folder, f"{file_root}_compressed.{selected_format}")
+                output_path: str = os.path.join(new_folder, f"{file_root}_compressed.{ext}")
 
                 # Save with compression if selected
                 quality_val = args.quality if compress_var.get() else 100

--- a/main.py
+++ b/main.py
@@ -90,18 +90,24 @@ def compress_images() -> None:
                 
                 # Determine File Extension
                 filename: str = os.path.basename(file)
-                file_root: Path = os.path.splitext(filename)[0]
+                file_root: str = os.path.splitext(filename)[0]
                 
                 if selected_format == 'JPEG':
                     ext = '.jpg'
                 else:
                     ext = f'.{selected_format.lower()}'
 
-                output_path: str = os.path.join(new_folder, f"{file_root}_compressed.{ext}")
+                output_path: str = os.path.join(new_folder, f"{file_root}_compressed{ext}")
+                
+                save_params = {'format': selected_format}
 
-                # Save with compression if selected
-                quality_val = args.quality if compress_var.get() else 100
-                img.save(output_path, format=selected_format, quality=quality_val)
+                # Only add quality if the format supports it
+                if selected_format in ['JPEG', 'WEBP']:
+                    quality_val = args.quality if compress_var.get() else 100
+                    save_params['quality'] = quality_val
+                
+                # Save with compression
+                img.save(output_path, **save_params)
 
         # Catch specific errors and Log instead of stopping
         except (UnidentifiedImageError, IOError) as e:


### PR DESCRIPTION
### Description
Closes #11

This PR adds the ability for users to select the output image format (JPEG, PNG, or WEBP). Previously, all images were forced to JPEG.

### Changes
- **UI:** Added a dropdown (`Combobox`) to select the output format.
- **Logic:** Updated `compress_images()` to:
    - distinct file extensions based on selection (`.jpg`, `.png`, `.webp`).
    - Pass the correct `format` argument to Pillow's `save()` method.
    - **Preserve Transparency:** Only converts images to RGB if "JPEG" is selected. PNG and WEBP now retain their transparency (RGBA).

### Testing
- Tested converting images to **PNG** (Transparency verified).
- Tested converting to **WEBP**.
- Verified default **JPEG** behavior remains unchanged.